### PR TITLE
Add when condition for package_rng-tools_installed

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -197,6 +197,7 @@ package_tmux_installed: true
 package_tuned_removed: true
 package_usbguard_installed: true
 package_vsftpd_removed: true
+package_rng-tools_installed: true
 patch_strategy: true
 postfix_client_configure_mail_alias: true
 reboot_required: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -617,6 +617,7 @@
   - low_disruption | bool
   - medium_severity | bool
   - no_reboot_needed | bool
+  - package_rng-tools_installed | bool
 
 - name: Ensure abrt-addon-ccpp is removed
   package:


### PR DESCRIPTION
Unlike most of the `package_*` variables, `package_rng-tools_installed` was only referenced in the tags of the related task and not in the when clause.