### PR TITLE
Fix create argument when modifying tmux.conf

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13736,7 +13736,7 @@
 - name: Insert correct line into /etc/tmux.conf
   lineinfile:
     path: /etc/tmux.conf
-    create: null
+    create: false
     regexp: \s*bind\s+\w\s+lock-session.*$
     mode: '0644'
     line: bind X lock-session


### PR DESCRIPTION
The create parameter for the lineinfile module needs to be a boolean value. This argument being set to null was causing the following error in ansible-core 2.15.0:

'argument ''create'' is of type <class ''NoneType''> and we were unable to convert to bool: <class ''NoneType''> cannot be converted to a bool'