### PR TITLE
(bugfix) regex global operator must be in beginning of regex

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2089,7 +2089,7 @@
   lineinfile:
     dest: /etc/sysconfig/sshd
     state: absent
-    regexp: ^\s*(?i)CRYPTO_POLICY.*$
+    regexp: (?i)^\s*CRYPTO_POLICY.*$
   tags:
   - CCE-80939-2
   - DISA-STIG-RHEL-08-010287


### PR DESCRIPTION
There is a global operator used in this regex. The other regex's in tasks/main.yml have the global operator at the beginning. Maybe this one was simply missed. Currently breaking the playbook for me.

RHEL 8.8
ansible-core 2.14
python 3.11