### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,11 @@ Next, check the playbook using (on the localhost) the following example:
 
     ansible-playbook -i "localhost," -c local --check playbook.yml
 
+If you encounter errors pertaining to _ini_file or sysctl, you may need additional ansible collections:
+
+    ansible-galaxy collection install community.general
+    ansible-galaxy collection install ansible.posix
+
 To deploy it, use (this may change configuration of your local machine!):
 
     ansible-playbook -i "localhost," -c local playbook.yml


### PR DESCRIPTION
The given instructions will fail on RHEL 8 (tested on Red Hat Enterprise Linux release 8.10 (Ootpa)) after installing ansible-core on a brand new machine without the noted collections in the pull request. Systems are missing required community.general and ansible.posix collections from ansible-galaxy which have ini_module and sysctl.

The two error messages are:
`[root@localhost ~]# ansible-playbook -i "localhost," -c local playbook.yml ERROR! couldn't resolve module/action 'ini_file'. This often indicates a misspelling, missing collection, or incorrect module path.`

and

`[root@localhost ~]# ansible-playbook -i "localhost," -c local playbook.yml ERROR! couldn't resolve module/action 'sysctl'. This often indicates a misspelling, missing collection, or incorrect module path.`

The solution for the first error is
`ansible-galaxy collection install community.general`

The solution for the second error is
`ansible-galaxy collection install ansible.posix`